### PR TITLE
Update genkeys() interface

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,3 +28,6 @@ Imports:
     readr,
     rlang
 RoxygenNote: 6.1.0
+Suggests: 
+    testthat,
+    withr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ LazyData: true
 BugReports: https://github.com/SurgicalInformatics/encryptr/issues
 URL: https://github.com/SurgicalInformatics/encryptr
 Imports:
+    askpass,
     dplyr,
     knitr,
     openssl,

--- a/R/genkeys.R
+++ b/R/genkeys.R
@@ -19,7 +19,8 @@
 #'
 #' @examples
 #' genkeys()
-genkeys <- function(private_key_name = "id_rsa", public_key_name = "id_rsa.pub"){
+genkeys <- function(private_key_name = "id_rsa",
+                    public_key_name = paste0(private_key_name, ".pub")){
   if(file.exists(private_key_name)){
     stop("Private key file with this name already exists. Delete it or change file name.")
   }

--- a/R/genkeys.R
+++ b/R/genkeys.R
@@ -10,6 +10,8 @@
 #'   reason.
 #' @param public_key_name Character string. Do not change default unless good
 #'   reason.
+#' @param password Password for private key. This password cannot be recovered
+#'   if lost, so please store the password in a safe location.
 #'
 #' @return Two files containing the public key and encrypted private key are
 #'   written to the working directory.
@@ -20,7 +22,8 @@
 #' @examples
 #' genkeys()
 genkeys <- function(private_key_name = "id_rsa",
-                    public_key_name = paste0(private_key_name, ".pub")){
+                    public_key_name = paste0(private_key_name, ".pub"),
+                    password = ask_pass()){
   if(file.exists(private_key_name)){
     stop("Private key file with this name already exists. Delete it or change file name.")
   }
@@ -31,10 +34,14 @@ genkeys <- function(private_key_name = "id_rsa",
   key <- openssl::rsa_keygen()
   pubkey <- as.list(key)$pubkey
 
-  openssl::write_pem(key,
-                     private_key_name,
-                     password = openssl::askpass(prompt = "Please choose a password for your private key.
-                                                 This password CANNOT be recovered if lost.
-                                                 Please store the password in a safe location."))
+  openssl::write_pem(key, private_key_name, password = password)
   openssl::write_pem(pubkey, public_key_name)
+}
+
+ask_pass <- function() {
+  askpass::askpass(prompt = paste(
+    "Please choose a password for your private key.",
+    "This password CANNOT be recovered if lost.",
+    "Please store the password in a safe location.",
+    sep = "\n"))
 }

--- a/R/genkeys.R
+++ b/R/genkeys.R
@@ -31,10 +31,9 @@ genkeys <- function(private_key_name = "id_rsa", public_key_name = "id_rsa.pub")
   pubkey <- as.list(key)$pubkey
 
   openssl::write_pem(key,
-                     "id_rsa",
+                     private_key_name,
                      password = openssl::askpass(prompt = "Please choose a password for your private key.
                                                  This password CANNOT be recovered if lost.
                                                  Please store the password in a safe location."))
-  openssl::write_pem(pubkey,
-                     "id_rsa.pub")
+  openssl::write_pem(pubkey, public_key_name)
 }

--- a/man/genkeys.Rd
+++ b/man/genkeys.Rd
@@ -4,7 +4,9 @@
 \alias{genkeys}
 \title{Create and write RSA private and public keys}
 \usage{
-genkeys(private_key_name = "id_rsa", public_key_name = "id_rsa.pub")
+genkeys(private_key_name = "id_rsa",
+  public_key_name = paste0(private_key_name, ".pub"),
+  password = ask_pass())
 }
 \arguments{
 \item{private_key_name}{Character string. Do not change default unless good
@@ -12,6 +14,9 @@ reason.}
 
 \item{public_key_name}{Character string. Do not change default unless good
 reason.}
+
+\item{password}{Password for private key. This password cannot be recovered
+if lost, so please store the password in a safe location.}
 }
 \value{
 Two files containing the public key and encrypted private key are

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(encryptr)
+
+test_check("encryptr")

--- a/tests/testthat/test-genkeys.R
+++ b/tests/testthat/test-genkeys.R
@@ -1,0 +1,52 @@
+context("test-genkeys")
+
+# Run tests in temp directory
+# https://github.com/r-lib/testthat/issues/664#issuecomment-340809997
+
+dir_empty <- function(x){
+  unlink(x, recursive = TRUE, force = TRUE)
+  dir.create(x)
+}
+
+test_with_dir <- function(desc, ...){
+  new <- tempfile()
+  dir_empty(new)
+  withr::with_dir( # or local_dir()
+    new = new,
+    code = {
+      tmp <- capture.output(
+        testthat::test_that(desc = desc, ...)
+      )
+    }
+  )
+  invisible()
+}
+
+test_with_dir("genkeys() defaults create id_rsa and id_rsa.pub", {
+  genkeys(password = NULL)
+  expect_true(file.exists("id_rsa"))
+  expect_true(file.exists("id_rsa.pub"))
+})
+
+test_with_dir("genkeys() errors if files already exist", {
+  genkeys(password = NULL)
+  expect_error(genkeys(password = NULL))
+})
+
+test_with_dir("genkeys() creates keys with requested names", {
+  genkeys("custom", password = NULL)
+  expect_true(file.exists("custom"))
+  expect_true(file.exists("custom.pub"))
+
+  genkeys("public", "private", password = NULL)
+  expect_true(file.exists("public"))
+  expect_true(file.exists("private"))
+})
+
+test_with_dir("genkeys() uses password argument", {
+  genkeys(password = "testpassword")
+  check_message <- "Message"
+  x <- openssl::rsa_encrypt(charToRaw(check_message), "id_rsa.pub")
+  y <- openssl::rsa_decrypt(x, "id_rsa", "testpassword")
+  expect_equal(rawToChar(y), check_message)
+})

--- a/tests/testthat/test-genkeys.R
+++ b/tests/testthat/test-genkeys.R
@@ -29,8 +29,10 @@ test_with_dir("genkeys() defaults create id_rsa and id_rsa.pub", {
 })
 
 test_with_dir("genkeys() errors if files already exist", {
-  genkeys(password = NULL)
-  expect_error(genkeys(password = NULL))
+  file.create("id_rsa.pub")
+  expect_error(genkeys(password = NULL), regexp = "Public key .+ exists")
+  file.create("id_rsa")
+  expect_error(genkeys(password = NULL), regexp = "Private key .+ exists")
 })
 
 test_with_dir("genkeys() creates keys with requested names", {


### PR DESCRIPTION
The changes I mentioned in #1 were pretty straightforward so I went ahead and implemented them.

I also added tests and updated the dependencies appropriately in `DESCRIPTION`.

One small note, I added `askpass` to Imports because `openssl::askpass()` is simply a re-export of `askpass`, so this won't increase the dependency weight of encryptr but does make the dependency graph more clear.